### PR TITLE
Always use scraping date for new assets.

### DIFF
--- a/src/include/asset/Asset.php
+++ b/src/include/asset/Asset.php
@@ -17,7 +17,6 @@ abstract class Asset
 	 * @param null|string $creatorGivenId 
 	 * @param string $title 
 	 * @param string $url 
-	 * @param DateTime $date 
 	 * @param AssetType $type 
 	 * @param Creator $creator 
 	 * @param array<string> $tags 
@@ -28,7 +27,6 @@ abstract class Asset
 		public ?string $creatorGivenId,
 		public string $title,
 		public string $url,
-		public DateTime $date,
 		public AssetType $type,
 		public Creator $creator,
 		public array $tags = [],

--- a/src/include/asset/ScrapedAsset.php
+++ b/src/include/asset/ScrapedAsset.php
@@ -17,7 +17,6 @@ class ScrapedAsset extends Asset
 	 * @param null|string $creatorGivenId 
 	 * @param string $title 
 	 * @param string $url 
-	 * @param DateTime $date 
 	 * @param AssetType $type 
 	 * @param Creator $creator 
 	 * @param ScrapedAssetStatus $status 
@@ -30,7 +29,6 @@ class ScrapedAsset extends Asset
 		?string $creatorGivenId,
 		string $title,
 		string $url,
-		DateTime $date,
 		AssetType $type,
 		Creator $creator,
 		public ScrapedAssetStatus $status,
@@ -42,7 +40,6 @@ class ScrapedAsset extends Asset
 			creatorGivenId: $creatorGivenId,
 			title: $title,
 			url: $url,
-			date: $date,
 			type: $type,
 			creator: $creator,
 			tags: $tags,
@@ -56,7 +53,7 @@ class ScrapedAsset extends Asset
 			creatorGivenId: $this->creatorGivenId,
 			title: $this->title,
 			url: $this->url,
-			date: $this->date,
+			date: new DateTime(),
 			type: $this->type,
 			creator: $this->creator,
 			tags: $this->tags,

--- a/src/include/asset/StoredAsset.php
+++ b/src/include/asset/StoredAsset.php
@@ -37,11 +37,10 @@ class StoredAsset extends Asset
 		?string $creatorGivenId,
 		string $title,
 		string $url,
-		DateTime $date,
+		public DateTime $date,
 		AssetType $type,
 		Creator $creator,
 		array $tags = [],
-
 		public StoredAssetStatus $status = StoredAssetStatus::ACTIVE,
 		public ?DateTime $lastSuccessfulValidation = NULL,
 	) {
@@ -50,7 +49,6 @@ class StoredAsset extends Asset
 			creatorGivenId: $creatorGivenId,
 			title: $title,
 			url: $url,
-			date: $date,
 			type: $type,
 			creator: $creator,
 			tags: $tags,

--- a/src/include/creator/logic/CreatorLogic3dTextures.php
+++ b/src/include/creator/logic/CreatorLogic3dTextures.php
@@ -93,7 +93,6 @@ class CreatorLogic3dTextures extends CreatorLogic
 							creatorGivenId: null,
 							title: $wpPost['title']['rendered'],
 							url: $wpPost['link'],
-							date: new DateTime($wpPost['date']),
 							tags: $tmpTags,
 							type: AssetType::PBR_MATERIAL,
 							creator: Creator::THREE_D_TEXTURES,

--- a/src/include/creator/logic/CreatorLogicAmbientCg.php
+++ b/src/include/creator/logic/CreatorLogicAmbientCg.php
@@ -69,7 +69,6 @@ class CreatorLogicAmbientCg extends CreatorLogic
 					$tmpAsset = new ScrapedAsset(
 						url: $acgAsset['shortLink'],
 						creatorGivenId: $acgAsset['assetId'] ?? NULL,
-						date: new DateTime($acgAsset['releaseDate']),
 						title: $acgAsset['displayName'],
 						tags: $acgAsset['tags'],
 						type: $this->typeMapping[$acgAsset['dataType']] ?? AssetType::OTHER,

--- a/src/include/creator/logic/CreatorLogicAmdGpuOpen.php
+++ b/src/include/creator/logic/CreatorLogicAmdGpuOpen.php
@@ -58,7 +58,6 @@ class CreatorLogicAmdGpuOpen extends CreatorLogic
 							creatorGivenId: $amdAsset['id'],
 							url: $url,
 							title: $amdAsset['title'],
-							date: new DateTime($amdAsset['published_date']),
 							tags: $tags,
 							type: AssetType::PBR_MATERIAL,
 							creator: Creator::GPUOPENMATLIB,

--- a/src/include/creator/logic/CreatorLogicCgBookcase.php
+++ b/src/include/creator/logic/CreatorLogicCgBookcase.php
@@ -57,7 +57,6 @@ class CreatorLogicCgBookcase extends CreatorLogic
 					creatorGivenId: null,
 					title: $metaTags['tex1:name'],
 					url: $url,
-					date: new DateTime($metaTags['tex1:release-date']),
 					tags: StringUtil::explodeFilterTrim(",", $metaTags['tex1:tags']),
 					type: AssetType::fromTex1Tag($metaTags['tex1:type']),
 					creator: Creator::CGBOOKCASE,

--- a/src/include/creator/logic/CreatorLogicCgMood.php
+++ b/src/include/creator/logic/CreatorLogicCgMood.php
@@ -90,7 +90,6 @@ class CreatorLogicCgMood extends CreatorLogic
 						creatorGivenId: null,
 						title: $assetImageElement->attr('data-product-title'),
 						url: $assetImageElement->attr('data-product-url'),
-						date: new DateTime(),
 						tags: array_values($tags),
 						type: $type,
 

--- a/src/include/creator/logic/CreatorLogicLightbeans.php
+++ b/src/include/creator/logic/CreatorLogicLightbeans.php
@@ -90,7 +90,6 @@ class CreatorLogicLightbeans extends CreatorLogic
 					creatorGivenId: null,
 					title: $title,
 					url: $newUrl,
-					date: new DateTime(),
 					tags: $tags,
 					type: $type,
 

--- a/src/include/creator/logic/CreatorLogicLocationTextures.php
+++ b/src/include/creator/logic/CreatorLogicLocationTextures.php
@@ -63,7 +63,6 @@ class CreatorLogicLocationTextures extends CreatorLogic
 							creatorGivenId: null,
 							title: $assetImageElement->attr('title'),
 							url: $assetLinkElement->attr('href'),
-							date: new DateTime(),
 							tags: array_merge(
 								array_filter(
 									preg_split('/[^A-Za-z0-9]/', $assetImageElement->attr('title')) ?: []

--- a/src/include/creator/logic/CreatorLogicNoEmotionsHdr.php
+++ b/src/include/creator/logic/CreatorLogicNoEmotionsHdr.php
@@ -38,12 +38,6 @@ class CreatorLogicNoEmotionsHdr extends CreatorLogic
 					id: NULL,
 					creatorGivenId: null,
 					title: $name,
-					date: new DateTime("2010-" . (
-						preg_split(
-							'/=|_/',
-							urldecode($url)
-						)
-						?: array("", "01-01"))[1]),
 					url: $url,
 					tags: ['Sky', $category],
 					type: AssetType::HDRI,

--- a/src/include/creator/logic/CreatorLogicPbrPx.php
+++ b/src/include/creator/logic/CreatorLogicPbrPx.php
@@ -144,7 +144,6 @@ class CreatorLogicPbrPx extends CreatorLogic
 						creatorGivenId: null,
 						title: $pbrPxAssetDetails['ename'],
 						url: $assetUrl,
-						date: new DateTime($pbrPxAsset['create_time']),
 						type: $type,
 						creator: $this->creator,
 						rawThumbnailData: new WebItemReference(

--- a/src/include/creator/logic/CreatorLogicPoliigon.php
+++ b/src/include/creator/logic/CreatorLogicPoliigon.php
@@ -102,7 +102,6 @@ class CreatorLogicPoliigon extends CreatorLogic
 						creatorGivenId: null,
 						title: $name,
 						url: $url,
-						date: new DateTime(),
 						tags: $tags,
 						type: $type,
 

--- a/src/include/creator/logic/CreatorLogicPolyhaven.php
+++ b/src/include/creator/logic/CreatorLogicPolyhaven.php
@@ -60,7 +60,6 @@ class CreatorLogicPolyhaven extends CreatorLogic
 					id: NULL,
 					creatorGivenId: null,
 					url: $url,
-					date: $date,
 					title: $phAsset['name'],
 					tags: $phAsset['tags'],
 					type: $this->typeMapping[intval($phAsset['type'])] ?? AssetType::OTHER,

--- a/src/include/creator/logic/CreatorLogicRawCatalog.php
+++ b/src/include/creator/logic/CreatorLogicRawCatalog.php
@@ -73,7 +73,6 @@ class CreatorLogicRawCatalog extends CreatorLogic
 						creatorGivenId: null,
 						url: $url,
 						title: (string) $rawCatalogAsset->name,
-						date: new DateTime((string) $rawCatalogAsset->updated),
 						tags: $tags,
 						type: $type,
 						creator: Creator::RAWCATALOG,

--- a/src/include/creator/logic/CreatorLogicShareTextures.php
+++ b/src/include/creator/logic/CreatorLogicShareTextures.php
@@ -41,7 +41,6 @@ class CreatorLogicShareTextures extends CreatorLogic
 					creatorGivenId: null,
 					title: $metaTags['og:title'] ?? throw new Exception("Could not resolve title from meta tags."),
 					url: $url,
-					date: new DateTime($metaTags['tex1:release-date'] ?? date('Y-m-d')),
 					type: AssetType::fromTex1Tag($metaTags['tex1:type'] ?? ""),
 					creator: $this->creator,
 					rawThumbnailData: new WebItemReference($metaTags['tex1:preview-image'])->fetch()->content,

--- a/src/include/creator/logic/CreatorLogicTextureCan.php
+++ b/src/include/creator/logic/CreatorLogicTextureCan.php
@@ -41,7 +41,6 @@ class CreatorLogicTextureCan extends CreatorLogic
 					creatorGivenId: null,
 					title: $metaTags['tex1:name'] ?? throw new Exception("Could not resolve title from meta tags."),
 					url: $url,
-					date: new DateTime($metaTags['tex1:release-date'] ?? date('Y-m-d')),
 					tags: StringUtil::explodeFilterTrim(",", $metaTags['tex1:tags'] ?? throw new Exception("Could not resolve tags from meta tags.")),
 					type: AssetType::fromTex1Tag($metaTags['tex1:type']),
 					creator: Creator::TEXTURECAN,

--- a/src/include/creator/logic/CreatorLogicTexturesCom.php
+++ b/src/include/creator/logic/CreatorLogicTexturesCom.php
@@ -79,7 +79,6 @@ class CreatorLogicTexturesCom extends CreatorLogic
 						creatorGivenId: null,
 						title: $texComAsset['defaultPhotoSet']['titleThumbnail'],
 						url: $url,
-						date: new DateTime($texComAsset['defaultPhotoSet']['createdAtUtc']),
 						tags: array_filter(
 							preg_split('/[^A-Za-z0-9]/', $texComAsset['defaultPhotoSet']['titleThumbnail']) ?: []
 						),

--- a/src/include/creator/logic/CreatorLogicThreeDScans.php
+++ b/src/include/creator/logic/CreatorLogicThreeDScans.php
@@ -41,7 +41,6 @@ class CreatorLogicThreeDScans extends CreatorLogic
 
 					// Extract year and month from thumbnail URL or use current date as a fallback
 					preg_match('/[0-9]{4}\/[0-9]{2}/', $assetImageElement->attr('src'), $matches);
-					$date = isset($matches[0]) ? str_replace('/', '-', $matches[0]) . "-01" : date("Y-m-d");
 
 					if (!$existingAssets->containsUrl($assetLinkElement->attr('href'))) {
 						$tmpCollection[] = new ScrapedAsset(
@@ -49,7 +48,6 @@ class CreatorLogicThreeDScans extends CreatorLogic
 							creatorGivenId: null,
 							title: $assetLinkElement->attr('title'),
 							url: $assetLinkElement->attr('href'),
-							date: new DateTime($date),
 							tags: array_merge(
 								array_filter(
 									preg_split(

--- a/src/include/creator/logic/CreatorLogicTwinbru.php
+++ b/src/include/creator/logic/CreatorLogicTwinbru.php
@@ -191,7 +191,6 @@ class CreatorLogicTwinbru extends CreatorLogic
 						creatorGivenId: null,
 						title: $name,
 						url: $assetUrl,
-						date: new DateTime($date),
 						tags: $tags,
 						type: $type,
 						creator: $this->creator,


### PR DESCRIPTION
Previously, the scraping would also get the date from the creator's website, but that messes with analytics and popularity scoring, so I'm changing it to always use the scraping date. Some creators also don't have publication dates on their site.